### PR TITLE
Use `view` to render text input

### DIFF
--- a/chatty/chatty.ml
+++ b/chatty/chatty.ml
@@ -78,7 +78,7 @@ let view model =
                Format.sprintf "%s > %s" user msg)
     |> String.concat "\n"
   in
-  messages ^ "\n\n> " ^ Text_input.current_text model.input_field
+  messages ^ "\n\n" ^ Text_input.view model.input_field
 
 let app = Minttea.app ~init ~update ~view ()
 


### PR DESCRIPTION
Not sure if this was intentional (or if the naming is off), but should be able to use `Text_input.view` to render the component. This would use the default prompt `> ` as well as render the cursor (whereas `current_text` would just give you the input's current value)!